### PR TITLE
Bring `torch.compile` to `quant_block_v2_`.

### DIFF
--- a/torchao/prototype/autoround/autoround_llm.py
+++ b/torchao/prototype/autoround/autoround_llm.py
@@ -5,7 +5,7 @@ import torch
 
 import torchao
 import torchao.prototype.autoround.utils as ar_utils
-
+from typing import Optional
 from torchao.prototype.autoround.core import (
     apply_auto_round,
     prepare_model_for_applying_auto_round_,
@@ -29,6 +29,7 @@ def quantize_model_with_autoround_(
     bs: int = 8,
     nsamples: int = 128,
     use_optimized_layer_output: bool = False,
+    compile_optimization_process:  Optional[bool] = False,
 ):
     # Step 1. Prepare the model for applying auto-round
 
@@ -42,6 +43,7 @@ def quantize_model_with_autoround_(
         group_size,
         iters,
         use_optimized_layer_output,
+        compile_optimization_process,
         device=device,
     )
 
@@ -107,6 +109,7 @@ def main(args):
         bs=args.train_bs,
         nsamples=args.nsamples,
         use_optimized_layer_output=args.use_optimized_layer_output,
+        compile_optimization_process=args.compile_optimization_process,
     )
     # Revert the `use_cache` for generation stage.
     model.config.use_cache = True
@@ -167,6 +170,13 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Use the optimized layer output for next layer or not",
+    )
+    parser.add_argument(
+        "-c",
+        "--compile_optimization_process",
+        default=False,
+        action="store_true",
+        help="Whether to compile the optimization process",
     )
     parser.add_argument(
         "-d",

--- a/torchao/prototype/autoround/core.py
+++ b/torchao/prototype/autoround/core.py
@@ -20,6 +20,7 @@ class _AutoRoundConfig:
     group_size: int = 128
     iters: int = 200
     use_optimized_layer_output: bool = False
+    compile_optimization_process: bool = False
 
 
 _auto_round_config = _AutoRoundConfig()
@@ -82,6 +83,7 @@ def prepare_model_for_applying_auto_round_(
     group_size: int = 128,
     iters: int = 200,
     use_optimized_layer_output: bool = False,
+    compile_optimization_process: Optional[bool] = False,
     device: Optional[torch.types.Device] = None,
 ):
     """Prepares the model for applying auto round optimization.
@@ -94,6 +96,7 @@ def prepare_model_for_applying_auto_round_(
         group_size (int, optional): The group size for quantization. Defaults to 128.
         iters (int, optional): The number of iterations for optimization. Defaults to 200.
         use_optimized_layer_output (bool, optional): Whether to use optimized layer output. Defaults to False.
+        compile_optimization_process (Optional[bool], optional): Whether to compile the optimization process. Defaults to False.
         device (Optional[torch.types.Device], optional): The device to use for accelrating optimization and calibration.
             Defaults to None.
     """
@@ -105,6 +108,7 @@ def prepare_model_for_applying_auto_round_(
     _auto_round_config.group_size = group_size
     _auto_round_config.iters = iters
     _auto_round_config.use_optimized_layer_output = use_optimized_layer_output
+    _auto_round_config.compile_optimization_process = compile_optimization_process
 
     logging.warning(f"config {_auto_round_config}")
 
@@ -315,6 +319,8 @@ def _apply_auto_round_optimization(
         amp=True,
         model_dtype=next(block.parameters()).dtype,
     )
+    if config.compile_optimization_process:
+        rounder.quant_block_v2_ = torch.compile(rounder.quant_block_v2_)
 
     with torch.enable_grad():
         rounder.quant_block_v2_(
@@ -326,7 +332,7 @@ def _apply_auto_round_optimization(
     block.to(orig_device)
 
 
-@ar_utils.dump_elapsed_time()
+@ar_utils.dump_elapsed_time(record=True)
 @torch.no_grad()
 def apply_auto_round_optimization(
     module: torch.nn.Module,

--- a/torchao/prototype/autoround/eval_autoround.py
+++ b/torchao/prototype/autoround/eval_autoround.py
@@ -121,6 +121,7 @@ def main(args):
                     bs=args.train_bs,
                     nsamples=args.nsamples,
                     use_optimized_layer_output=args.use_optimized_layer_output,
+                    compile_optimization_process=args.compile_optimization_process,
                 )
             quantized_layer_cnt = ar_utils.count_tensor_of_type(
                 model, torchao.dtypes.AffineQuantizedTensor
@@ -183,6 +184,13 @@ if __name__ == "__main__" and TORCH_VERSION_AT_LEAST_2_5 and torch.cuda.is_avail
         default=False,
         action="store_true",
         help="Use the optimized layer output for next layer or not",
+    )
+    parser.add_argument(
+        "-c",
+        "--compile_optimization_process",
+        default=False,
+        action="store_true",
+        help="Whether to compile the optimization process",
     )
     parser.add_argument(
         "-d",

--- a/torchao/prototype/autoround/utils.py
+++ b/torchao/prototype/autoround/utils.py
@@ -6,6 +6,7 @@ import random
 
 import numpy as np
 import torch
+import collections
 
 
 def _is_package_available(pkg_name, metadata_name=None):
@@ -149,8 +150,8 @@ def get_float_model_info(model_name_or_path, torch_dtype=torch.float32):
         )
     return model, tokenizer, decoder_cls
 
-
-def dump_elapsed_time(customized_msg=""):
+execution_records = collections.defaultdict(list)
+def dump_elapsed_time(customized_msg="", record=False):
     """Get the elapsed time for decorated functions.
 
     Args:
@@ -164,13 +165,22 @@ def dump_elapsed_time(customized_msg=""):
             start = time.time()
             res = func(*args, **kwargs)
             end = time.time()
+            dur = round((end - start) * 1000, 2)
+            if record:
+                execution_records[func.__qualname__].append(dur)
             logging.warning(
                 "%s elapsed time: %s ms"
                 % (
                     customized_msg if customized_msg else func.__qualname__,
-                    round((end - start) * 1000, 2),
+                    dur,
                 )
             )
+            if record:
+                avg_time = sum(execution_records[func.__qualname__])/len(execution_records[func.__qualname__])
+                std_time = np.std(execution_records[func.__qualname__])
+                logging.warning(
+                    f"For {func.__qualname__}, the average elapsed time: {avg_time: .2f} ms, the std: {std_time: .2f} ms"
+                )
             return res
 
         return fi


### PR DESCRIPTION
Speedup the `AutoRound` optimization process:
- `meta-llama/Llama-2-7b-chat-hf`, about 1.29x ,  27 s/block -> 21 s/block
- `meta-llama/Meta-Llama-3.1-8B-Instruct`, about 1.23x, 32 s/block -> 26 s/block